### PR TITLE
refactor(client): remove the TokenProvider type argument

### DIFF
--- a/src/command/v1/client.rs
+++ b/src/command/v1/client.rs
@@ -2,46 +2,41 @@ use crate::error::ClientError;
 use crate::openid::TokenProvider;
 use crate::util::Client as TraitClient;
 use serde::Serialize;
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 use tracing::instrument;
 use url::Url;
 
 /// A client for drogue cloud command and control API, backed by reqwest.
 #[derive(Clone, Debug)]
-pub struct Client<TP>
-where
-    TP: TokenProvider,
-{
+pub struct Client {
     client: reqwest::Client,
     api_url: Url,
-    token_provider: TP,
+    token_provider: Arc<dyn TokenProvider>,
 }
 
-type ClientResult<T> = Result<T, ClientError<reqwest::Error>>;
+type ClientResult<T> = Result<T, ClientError>;
 
-impl<TP> TraitClient<TP> for Client<TP>
-where
-    TP: TokenProvider,
-{
+impl TraitClient for Client {
     fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    fn token_provider(&self) -> &TP {
-        &self.token_provider
+    fn token_provider(&self) -> &dyn TokenProvider {
+        self.token_provider.as_ref()
     }
 }
 
-impl<TP> Client<TP>
-where
-    TP: TokenProvider,
-{
+impl Client {
     /// Create a new client instance.
-    pub fn new(client: reqwest::Client, api_url: Url, token_provider: TP) -> Self {
+    pub fn new(
+        client: reqwest::Client,
+        api_url: Url,
+        token_provider: impl TokenProvider + 'static,
+    ) -> Self {
         Self {
             client,
             api_url,
-            token_provider,
+            token_provider: Arc::new(token_provider),
         }
     }
 

--- a/src/openid/inject.rs
+++ b/src/openid/inject.rs
@@ -9,25 +9,14 @@ use tracing::instrument;
 /// Allows injecting tokens.
 #[async_trait]
 pub trait TokenInjector: Sized + Send + Sync {
-    async fn inject_token<TP>(
-        self,
-        token_provider: &TP,
-    ) -> Result<Self, ClientError<reqwest::Error>>
-    where
-        TP: TokenProvider;
+    async fn inject_token(self, token_provider: &dyn TokenProvider) -> Result<Self, ClientError>;
 }
 
 /// Injects tokens into a request by setting the authorization header to a "bearer" token.
 #[async_trait]
 impl TokenInjector for reqwest::RequestBuilder {
     #[instrument(skip(token_provider))]
-    async fn inject_token<TP>(
-        self,
-        token_provider: &TP,
-    ) -> Result<Self, ClientError<reqwest::Error>>
-    where
-        TP: TokenProvider,
-    {
+    async fn inject_token(self, token_provider: &dyn TokenProvider) -> Result<Self, ClientError> {
         if let Some(credentials) = token_provider
             .provide_access_token()
             .await

--- a/src/openid/provider/access_token.rs
+++ b/src/openid/provider/access_token.rs
@@ -23,9 +23,7 @@ impl Debug for AccessTokenProvider {
 
 #[async_trait]
 impl TokenProvider for AccessTokenProvider {
-    type Error = reqwest::Error;
-
-    async fn provide_access_token(&self) -> Result<Option<Credentials>, ClientError<Self::Error>> {
+    async fn provide_access_token(&self) -> Result<Option<Credentials>, ClientError> {
         Ok(Some(Credentials::Basic(
             self.user.clone(),
             Some(self.token.clone()),

--- a/src/openid/provider/openid.rs
+++ b/src/openid/provider/openid.rs
@@ -100,11 +100,7 @@ impl OpenIdTokenProvider {
 #[cfg(feature = "reqwest")]
 #[async_trait]
 impl TokenProvider for OpenIdTokenProvider {
-    type Error = reqwest::Error;
-
-    async fn provide_access_token(
-        &self,
-    ) -> Result<Option<Credentials>, crate::error::ClientError<reqwest::Error>> {
+    async fn provide_access_token(&self) -> Result<Option<Credentials>, crate::error::ClientError> {
         self.provide_token()
             .await
             .map(|token| Some(Credentials::Bearer(token.access_token)))

--- a/src/tokens/v1/client.rs
+++ b/src/tokens/v1/client.rs
@@ -2,46 +2,41 @@ use super::data::*;
 use crate::error::ClientError;
 use crate::openid::TokenProvider;
 use crate::util::Client as ClientTrait;
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 use tracing::instrument;
 use url::Url;
 
 /// A client for the token management API, backed by reqwest.
 #[derive(Clone, Debug)]
-pub struct Client<TP>
-where
-    TP: TokenProvider,
-{
+pub struct Client {
     client: reqwest::Client,
     api_url: Url,
-    token_provider: TP,
+    token_provider: Arc<dyn TokenProvider>,
 }
 
-type ClientResult<T> = Result<T, ClientError<reqwest::Error>>;
+type ClientResult<T> = Result<T, ClientError>;
 
-impl<TP> ClientTrait<TP> for Client<TP>
-where
-    TP: TokenProvider,
-{
+impl ClientTrait for Client {
     fn client(&self) -> &reqwest::Client {
         &self.client
     }
 
-    fn token_provider(&self) -> &TP {
-        &self.token_provider
+    fn token_provider(&self) -> &dyn TokenProvider {
+        self.token_provider.as_ref()
     }
 }
 
-impl<TP> Client<TP>
-where
-    TP: TokenProvider,
-{
+impl Client {
     /// Create a new client instance.
-    pub fn new(client: reqwest::Client, api_url: Url, token_provider: TP) -> Self {
+    pub fn new(
+        client: reqwest::Client,
+        api_url: Url,
+        token_provider: impl TokenProvider + 'static,
+    ) -> Self {
         Self {
             client,
             api_url,
-            token_provider,
+            token_provider: Arc::new(token_provider),
         }
     }
 


### PR DESCRIPTION
BREAKING CHANGE: This change drops the TokenProvider type argument from
  the API. With that, it also is only possible to get a StdError from
  the token provider operation.