### PR TITLE
Add a field to store the HTTP status in Errors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1"
 url = "2"
 
 http = { version = "0.2", optional = true }
+http-serde = { version = "1.1.0", optional = true }
 nom = { version = "6", optional = true }
 openid = { version = "0.9.1", optional = true }
 opentelemetry = { version = "0.17", optional = true }
@@ -37,10 +38,10 @@ reqwest = { version = "0.11", features = ["json"], optional = true }
 reqwest-wasm-ext = { git = "https://github.com/ctron/reqwest-wasm-ext.git", optional = true }
 
 [features]
-default = ["reqwest", "openid", "telemetry", "nom"]
+default = ["reqwest", "openid", "telemetry", "nom", "http-serde"]
 telemetry = ["opentelemetry", "opentelemetry-http", "http"]
 # alternate default target for wasm
-wasm = ["reqwest", "reqwest-wasm-ext", "nom"]
+wasm = ["reqwest", "reqwest-wasm-ext", "nom", "http-serde"]
 reqwest = ["dep:reqwest", "reqwest-wasm-ext"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ tracing = "0.1"
 url = "2"
 
 http = { version = "0.2", optional = true }
-http-serde = { version = "1.1.0", optional = true }
 nom = { version = "6", optional = true }
 openid = { version = "0.9.1", optional = true }
 opentelemetry = { version = "0.17", optional = true }
@@ -38,10 +37,10 @@ reqwest = { version = "0.11", features = ["json"], optional = true }
 reqwest-wasm-ext = { git = "https://github.com/ctron/reqwest-wasm-ext.git", optional = true }
 
 [features]
-default = ["reqwest", "openid", "telemetry", "nom", "http-serde"]
+default = ["reqwest", "openid", "telemetry", "nom"]
 telemetry = ["opentelemetry", "opentelemetry-http", "http"]
 # alternate default target for wasm
-wasm = ["reqwest", "reqwest-wasm-ext", "nom", "http-serde"]
+wasm = ["reqwest", "reqwest-wasm-ext", "nom"]
 reqwest = ["dep:reqwest", "reqwest-wasm-ext"]
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,17 +5,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use url::ParseError;
 
-// /// A service error
-// /// Additional error information provided by the service may be contained in the error option
-// #[derive(Clone, Debug, Serialize, Deserialize)]
-// pub struct ServiceError {
-//     /// A machine processable HTTP Status code.
-//     #[serde(with = "http_serde::status_code")]
-//     pub code: StatusCode,
-//     /// Optional additional error information
-//     #[serde(default)]
-//     pub error: Option<ErrorInformation>,
-// }
 
 /// Additional error information.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 //! Error and error information.
 
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use url::ParseError;
@@ -9,6 +10,9 @@ use url::ParseError;
 pub struct ErrorInformation {
     /// A machine processable error type.
     pub error: String,
+    /// A machine processable HTTP Status code.
+    #[serde(with = "http_serde::status_code")]
+    pub status: StatusCode,
     /// A human readable error message.
     #[serde(default)]
     pub message: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use url::ParseError;
 
-
 /// Additional error information.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ErrorInformation {
@@ -25,8 +24,14 @@ pub enum ClientError {
     #[error("request error: {0}")]
     Request(String),
     /// A remote error, performing the request.
-    #[error("service error. HTTP {code}")]
-    Service { code: StatusCode, error: Option<ErrorInformation>},
+    #[error("service error. HTTP {0}")]
+    Response(StatusCode),
+    /// A remote error, performing the request, with additional details
+    #[error("service error. HTTP {code}. {error}")]
+    Service {
+        code: StatusCode,
+        error: ErrorInformation,
+    },
     /// A token provider error.
     #[error("token error: {0}")]
     Token(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,17 +5,17 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use url::ParseError;
 
-/// A service error
-/// Additional error information provided by the service may be contained in the error option
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ServiceError {
-    /// A machine processable HTTP Status code.
-    #[serde(with = "http_serde::status_code")]
-    pub code: StatusCode,
-    /// Optional additional error information
-    #[serde(default)]
-    pub error: Option<ErrorInformation>,
-}
+// /// A service error
+// /// Additional error information provided by the service may be contained in the error option
+// #[derive(Clone, Debug, Serialize, Deserialize)]
+// pub struct ServiceError {
+//     /// A machine processable HTTP Status code.
+//     #[serde(with = "http_serde::status_code")]
+//     pub code: StatusCode,
+//     /// Optional additional error information
+//     #[serde(default)]
+//     pub error: Option<ErrorInformation>,
+// }
 
 /// Additional error information.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -36,8 +36,8 @@ pub enum ClientError {
     #[error("request error: {0}")]
     Request(String),
     /// A remote error, performing the request.
-    #[error("service error: {0}")]
-    Service(ServiceError),
+    #[error("service error. HTTP {code}")]
+    Service { code: StatusCode, error: Option<ErrorInformation>},
     /// A token provider error.
     #[error("token error: {0}")]
     Token(#[source] Box<dyn std::error::Error + Send + Sync>),
@@ -77,16 +77,6 @@ impl fmt::Display for ErrorInformation {
             write!(f, "{}", self.message)
         } else {
             write!(f, "{}: {}", self.error, self.message)
-        }
-    }
-}
-
-impl fmt::Display for ServiceError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(e) = self.error.clone() {
-            write!(f, "HTTP {}\n{}", self.code, e)
-        } else {
-            write!(f, "Error. HTTP {}", self.code)
         }
     }
 }

--- a/src/util/client/mod.rs
+++ b/src/util/client/mod.rs
@@ -194,15 +194,21 @@ pub trait Client {
                     Ok(json) => ErrorInformation {
                         error: json,
                         message: format!("HTTP {}", code),
+                        status: code,
                     },
                     Err(_) => ErrorInformation {
                         error: String::default(),
                         message: format!("HTTP error {}", code),
+                        status: code,
                     },
                 };
                 Err(ClientError::Service(error))
             }
-            code => Err(ClientError::Request(format!("Unexpected code {:?}", code))),
+            code => Err(ClientError::Service(ErrorInformation {
+                error: String::default(),
+                message: format!("Unexpected HTTP code {:?}", code),
+                status: code,
+            })),
         }
     }
 }

--- a/src/util/client/mod.rs
+++ b/src/util/client/mod.rs
@@ -66,6 +66,7 @@ pub trait Client {
         log::debug!("Eval get response: {:#?}", response);
         match response.status() {
             StatusCode::OK => Ok(Some(response.json().await?)),
+            StatusCode::NOT_FOUND => Ok(None),
             _ => Self::default_response(response).await,
         }
     }

--- a/src/util/client/mod.rs
+++ b/src/util/client/mod.rs
@@ -1,6 +1,6 @@
 use crate::core::PropagateCurrentContext;
 use crate::openid::TokenProvider;
-use crate::{error::ClientError, error::ServiceError, openid::TokenInjector};
+use crate::{error::ClientError, openid::TokenInjector};
 
 use async_trait::async_trait;
 use reqwest::{Response, StatusCode};
@@ -65,10 +65,10 @@ pub trait Client {
         log::debug!("Eval get response: {:#?}", response);
         match response.status() {
             StatusCode::OK => Ok(Some(response.json().await?)),
-            StatusCode::NOT_FOUND => Err(ClientError::Service(ServiceError {
+            StatusCode::NOT_FOUND => Err(ClientError::Service{
                 code: StatusCode::NOT_FOUND,
                 error: response.json().await.ok(),
-            })),
+            }),
             _ => Self::default_response(response).await,
         }
     }
@@ -191,9 +191,9 @@ pub trait Client {
     }
 
     async fn default_response<T>(response: Response) -> Result<T, ClientError> {
-        Err(ClientError::Service(ServiceError {
+        Err(ClientError::Service {
             code: response.status(),
             error: response.json().await.ok(),
-        }))
+        })
     }
 }


### PR DESCRIPTION
Having the status code chucked in the string message made it hard to
machine-read it. The only uses of the "message" field where simply
copying the code in there. I moved that to the display impl.